### PR TITLE
Fixed the correct default value in the comments

### DIFF
--- a/chapters/chapter-2_Core_Principles_and_use_cases/utility.ts
+++ b/chapters/chapter-2_Core_Principles_and_use_cases/utility.ts
@@ -43,7 +43,7 @@ class TodoItem {
 
 const item = new TodoItem({ description: "Some description" });
 console.debug(item.description); // prints "Some description"
-console.debug(item.title); // prints "Some description"
+console.debug(item.title); // prints "Default item title"
 
 type OriginalTodoItemProps = Required<Partial<TodoItemProps>>; // type is same as TodoItemProps
 


### PR DESCRIPTION
The default value of title in the TodoItem class is different than what the comment in the console.log suggests which can be misleading/confusing to readers. 